### PR TITLE
ci(workflows): switch to shared force merge workflow

### DIFF
--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -1,0 +1,15 @@
+name: "Force merge automation"
+description: Merge a pull request when N committers post a comment with the command /force-merge
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  call-workflow-in-public-repo:
+    uses: eclipse-kura/.github/.github/workflows/_shared-force-merge.yml@main


### PR DESCRIPTION
Switch to shared Github action introduced in https://github.com/eclipse-kura/.github/pull/9 for `force-merge` workflow.

**Note**: requires https://github.com/eclipse-kura/.github/pull/9 to be merged to work.