### PR TITLE
build: renaming bom dependencies to pde-deps

### DIFF
--- a/kura-wires-pde-deps/pom.xml
+++ b/kura-wires-pde-deps/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -19,11 +19,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.eclipse.kura</groupId>
-    <artifactId>kura-wires-bom</artifactId>
+    <artifactId>kura-wires-pde-deps</artifactId>
     <version>3.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
-    <name>Kura Wires BOM</name>
+    <name>Kura Wires PDE Dependencies</name>
 
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,6 @@
         <module>bundles</module>
         <module>distrib</module>
         <module>tests</module>
-        <module>kura-wires-bom</module>
+        <module>kura-wires-pde-deps</module>
     </modules>
 </project>

--- a/target-definition/kura-wires.target
+++ b/target-definition/kura-wires.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <!--
 
-    Copyright (c) 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -22,13 +22,13 @@
             <dependencies>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>target-platform-bom</artifactId>
+                    <artifactId>target-platform-pde-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.kura</groupId>
-                    <artifactId>kura-bom</artifactId>
+                    <artifactId>kura-pde-deps</artifactId>
                     <version>6.0.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>


### PR DESCRIPTION
The POMs in the esf-bom and target-platform-bom projects in kura-core are not Maven BOM POMs according to the official Maven [documentation on the subject](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs): this can cause great confusion, especially since that is a Maven standard. Those projects were renamed in the kura-core repo, so the depencies here must be aligned.

This PR renames the projects and all their occurences in the framework like:

- kura-bom --> kura-pde-deps
- target-platform-bom --> target-platform-pde-deps