### PR TITLE
feat: Made PositionService optional for Wire publisher

### DIFF
--- a/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
+++ b/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
@@ -30,7 +30,7 @@
       <provide interface="org.osgi.service.wireadmin.Consumer"/>
    </service>
    <reference bind="bindWireHelperService" cardinality="1..1" interface="org.eclipse.kura.wire.WireHelperService" name="WireHelperService" policy="static"/>
-   <reference bind="setPositionService" cardinality="1..1" interface="org.eclipse.kura.position.PositionService" name="PositionService" policy="static"/>
+   <reference bind="setPositionService" unbind="unsetPositionService" cardinality="0..1" interface="org.eclipse.kura.position.PositionService" name="PositionService" policy="dynamic"/>
    <reference name="CloudPublisher"
            policy="dynamic"
            bind="setCloudPublisher"

--- a/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
+++ b/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-   Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+   Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
   
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0

--- a/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
+++ b/bundles/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
@@ -33,7 +33,7 @@
             cardinality="0"
             required="true"
             default="none"
-            description="Whether or not the gateway's position should be published in the message. Choices are: None - means that no position will be published; Basic - only altitude, longitude and latitude values will be published; Full - available NMEA properties will be mapped to a KuraPosition object and published.">
+            description="Whether or not the gateway's position should be published in the message. Choices are: None - means that no position will be published; Basic - only altitude, longitude and latitude values will be published; Full - available NMEA properties will be mapped to a KuraPosition object and published. Note that in order to publish position information, the Position Service must be available.">
             <Option label="None" value="none" />
             <Option label="Basic" value="basic" />
             <Option label="Full" value="full" />

--- a/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -49,11 +49,13 @@ import org.osgi.service.wireadmin.Wire;
 
 /**
  * The Class CloudPublisher is the specific Wire Component to publish a list of
- * {@link WireRecord}s as received in {@link WireEnvelope} to the configured cloud
+ * {@link WireRecord}s as received in {@link WireEnvelope} to the configured
+ * cloud
  * platform.<br/>
  * <br/>
  *
- * For every {@link WireRecord} as found in {@link WireEnvelope} will be wrapped inside a Kura
+ * For every {@link WireRecord} as found in {@link WireEnvelope} will be wrapped
+ * inside a Kura
  * Payload and will be sent to the Cloud Platform.
  */
 public final class CloudPublisher implements WireReceiver, ConfigurableComponent {
@@ -63,7 +65,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
     private CloudPublisherOptions cloudPublisherOptions;
 
     private volatile WireHelperService wireHelperService;
-    private PositionService positionService;
+    private Optional<PositionService> positionService = Optional.empty();
 
     private WireSupport wireSupport;
 
@@ -79,7 +81,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * Binds the Wire Helper Service.
      *
      * @param wireHelperService
-     *            the new Wire Helper Service
+     *                          the new Wire Helper Service
      */
     public void bindWireHelperService(final WireHelperService wireHelperService) {
         if (isNull(this.wireHelperService)) {
@@ -88,7 +90,13 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
     }
 
     public void setPositionService(PositionService positionService) {
-        this.positionService = positionService;
+        this.positionService = Optional.ofNullable(positionService);
+    }
+
+    public void unsetPositionService(PositionService positionService) {
+        if (positionService == this.positionService.orElse(null)) {
+            this.positionService = Optional.empty();
+        }
     }
 
     public void setCloudPublisher(org.eclipse.kura.cloudconnection.publisher.CloudPublisher cloudPublisher) {
@@ -111,9 +119,9 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * OSGi Service Component callback for activation.
      *
      * @param componentContext
-     *            the component context
+     *                         the component context
      * @param properties
-     *            the properties
+     *                         the properties
      */
     protected void activate(final ComponentContext componentContext, final Map<String, Object> properties) {
         logger.debug("Activating Cloud Publisher Wire Component...");
@@ -130,7 +138,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * OSGi Service Component callback for updating.
      *
      * @param properties
-     *            the updated properties
+     *                   the updated properties
      */
     public void updated(final Map<String, Object> properties) {
         logger.debug("Updating Cloud Publisher Wire Component...");
@@ -144,7 +152,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * OSGi Service Component callback for deactivation.
      *
      * @param componentContext
-     *            the component context
+     *                         the component context
      */
     protected void deactivate(final ComponentContext componentContext) {
         logger.debug("Deactivating Cloud Publisher Wire Component...");
@@ -185,10 +193,10 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * Builds the Kura payload from the provided {@link WireRecord}.
      *
      * @param wireRecord
-     *            the {@link WireRecord}
+     *                   the {@link WireRecord}
      * @return the Kura payload
      * @throws NullPointerException
-     *             if the {@link WireRecord} provided is null
+     *                              if the {@link WireRecord} provided is null
      */
     private KuraPayload buildKuraPayload(final WireRecord wireRecord) {
         requireNonNull(wireRecord, "Wire Record cannot be null");
@@ -197,10 +205,11 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
         kuraPayload.setTimestamp(new Date());
 
         if (this.cloudPublisherOptions.getPositionType() != PositionType.NONE) {
-            KuraPosition kuraPosition = getPosition();
-            kuraPayload.setPosition(kuraPosition);
+            this.positionService.ifPresentOrElse(
+                    service -> kuraPayload.setPosition(getPosition()),
+                    () -> logger.warn(
+                            "Position Service is not available, cannot enrich message with position information."));
         }
-
         final Map<String, TypedValue<?>> wireRecordProperties = wireRecord.getProperties();
 
         for (final Entry<String, TypedValue<?>> entry : wireRecordProperties.entrySet()) {
@@ -242,7 +251,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
     }
 
     private KuraPosition getPosition() {
-        NmeaPosition position = this.positionService.getNmeaPosition();
+        NmeaPosition position = this.positionService.get().getNmeaPosition();
 
         KuraPosition kuraPosition = new KuraPosition();
         kuraPosition.setAltitude(position.getAltitude());
@@ -263,9 +272,9 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
      * Publishes the list of provided {@link WireRecord}s
      *
      * @param wireRecords
-     *            the provided list of {@link WireRecord}s
+     *                    the provided list of {@link WireRecord}s
      * @throws NullPointerException
-     *             if one of the arguments is null
+     *                              if one of the arguments is null
      */
     private void publish(final List<WireRecord> wireRecords) {
         requireNonNull(wireRecords, "Wire Records cannot be null");

--- a/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -65,7 +65,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
     private CloudPublisherOptions cloudPublisherOptions;
 
     private volatile WireHelperService wireHelperService;
-    private Optional<PositionService> positionService = Optional.empty();
+    private volatile Optional<PositionService> positionService = Optional.empty();
 
     private WireSupport wireSupport;
 

--- a/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -89,11 +89,11 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
         }
     }
 
-    public void setPositionService(PositionService positionService) {
+    public synchronized void setPositionService(PositionService positionService) {
         this.positionService = Optional.ofNullable(positionService);
     }
 
-    public void unsetPositionService(PositionService positionService) {
+    public synchronized void unsetPositionService(PositionService positionService) {
         if (positionService == this.positionService.orElse(null)) {
             this.positionService = Optional.empty();
         }
@@ -205,10 +205,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
         kuraPayload.setTimestamp(new Date());
 
         if (this.cloudPublisherOptions.getPositionType() != PositionType.NONE) {
-            this.positionService.ifPresentOrElse(
-                    service -> kuraPayload.setPosition(getPosition()),
-                    () -> logger.warn(
-                            "Position Service is not available, cannot enrich message with position information."));
+            setKuraPosition(kuraPayload);
         }
         final Map<String, TypedValue<?>> wireRecordProperties = wireRecord.getProperties();
 
@@ -250,9 +247,14 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
         }
     }
 
-    private KuraPosition getPosition() {
-        NmeaPosition position = this.positionService.get().getNmeaPosition();
+    private synchronized void setKuraPosition(KuraPayload kuraPayload) {
+        if (this.positionService.isEmpty()) {
+            logger.debug(
+                    "Position Service is not available, cannot enrich message with position information.");
+            return;
+        }
 
+        NmeaPosition position = this.positionService.get().getNmeaPosition();
         KuraPosition kuraPosition = new KuraPosition();
         kuraPosition.setAltitude(position.getAltitude());
         kuraPosition.setLatitude(position.getLatitude());
@@ -264,8 +266,7 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
             kuraPosition.setSpeed(position.getSpeed());
             kuraPosition.setSatellites(position.getNrSatellites());
         }
-
-        return kuraPosition;
+        kuraPayload.setPosition(kuraPosition);
     }
 
     /**

--- a/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/bundles/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/distrib/deb/control/control
+++ b/distrib/deb/control/control
@@ -2,7 +2,8 @@ Package: [[package.name]]
 Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
-Depends: kura-core (>= 6.0.0~), kura-core(<< 7.0.0~)
+Depends: kura-core (>= 6.0.0~), kura-core (<< 7.0.0~)
+Suggests: kura-position (>= 2.0.0~), kura-position (<< 3.0.0~)
 Architecture: [[deb.architecture]]
 Maintainer: Eclipse Kura Developers <kura-dev@eclipse.org>
 Description: [[summary]]

--- a/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
+++ b/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +30,6 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.cloudconnection.listener.CloudConnectionListener;
 import org.eclipse.kura.cloudconnection.listener.CloudDeliveryListener;
 import org.eclipse.kura.cloudconnection.message.KuraMessage;
-import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.message.KuraPayload;
 import org.eclipse.kura.message.KuraPosition;
 import org.eclipse.kura.position.NmeaPosition;
@@ -56,7 +54,7 @@ public class CloudPublisherTest {
     private CloudPublisher cp;
     private org.eclipse.kura.cloudconnection.publisher.CloudPublisher cloudPublisherMock;
     private Map<String, Object> properties;
-    private Optional<PositionService> positionServiceMock;
+    private PositionService positionServiceMock;
     private FakeCloudPublisher fakeCloudPublisher;
     private Map<String, TypedValue<?>> recordProps;
     private KuraPayload payload;
@@ -311,7 +309,7 @@ public class CloudPublisherTest {
     }
 
     private void givenPositionServiceMock() {
-        this.positionServiceMock = Optional.of(mock(PositionService.class));
+        this.positionServiceMock = mock(PositionService.class);
     }
 
     private void givenFakeCloudPublisher() {
@@ -347,9 +345,13 @@ public class CloudPublisherTest {
     }
 
     private void whenSetPositionServiceMock() throws NoSuchFieldException {
-        when(this.positionServiceMock.get().getNmeaPosition())
+        when(this.positionServiceMock.getNmeaPosition())
                 .thenReturn(new NmeaPosition(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
-        TestUtil.setFieldValue(this.cp, "positionService", this.positionServiceMock);
+        this.cp.setPositionService(this.positionServiceMock);
+    }
+
+    private void whenUnsetPositionServiceMock() {
+        this.cp.unsetPositionService(this.positionServiceMock);
     }
 
     private void whenKuraMessageReceived() {

--- a/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
+++ b/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
@@ -231,6 +231,29 @@ public class CloudPublisherTest {
         thenCheckDefaultKuraMessageProps();
     }
 
+    @Test
+    public void testPayloadHasNotPositionIfPositionServiceIsUnset()
+            throws InvalidSyntaxException, NoSuchFieldException {
+        givenCloudPublisher();
+        givenDefaultProperties();
+        givenUpdatedProperties("publish.position", "full");
+        givenActivatedComponentProperties();
+        givenPositionServiceMock();
+        givenDefaultRecordProp();
+
+        whenSetPositionServiceMock();
+        whenOnWireReceive();
+        whenKuraMessageReceived();
+
+        thenCheckFullPosition();
+
+        whenUnsetPositionServiceMock();
+        whenOnWireReceive();
+        whenKuraMessageReceived();
+
+        thenPayloadHasNullPosition();
+    }
+
     /*
      * Steps
      */

--- a/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
+++ b/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,7 +56,7 @@ public class CloudPublisherTest {
     private CloudPublisher cp;
     private org.eclipse.kura.cloudconnection.publisher.CloudPublisher cloudPublisherMock;
     private Map<String, Object> properties;
-    private PositionService positionServiceMock;
+    private Optional<PositionService> positionServiceMock;
     private FakeCloudPublisher fakeCloudPublisher;
     private Map<String, TypedValue<?>> recordProps;
     private KuraPayload payload;
@@ -64,7 +65,7 @@ public class CloudPublisherTest {
     private Map<String, Object> kuraMessageProps;
 
     @Test
-    public void testOnWireReceive() throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+    public void testOnWireReceive() throws InvalidSyntaxException {
         // test publishing a normal message with topic replacement
         givenCloudPublisher();
         givenDefaultProperties();
@@ -84,7 +85,7 @@ public class CloudPublisherTest {
     }
 
     @Test
-    public void testOnWireReceiveSetBody() throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+    public void testOnWireReceiveSetBody() throws InvalidSyntaxException {
         // test publishing a normal message with topic replacement
         givenCloudPublisher();
         givenDefaultProperties();
@@ -105,8 +106,7 @@ public class CloudPublisherTest {
     }
 
     @Test
-    public void testOnWireReceiveSetBodyRemoveFromMetrics()
-            throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+    public void testOnWireReceiveSetBodyRemoveFromMetrics() throws InvalidSyntaxException {
         // test publishing a normal message with topic replacement
         givenCloudPublisher();
         givenDefaultProperties();
@@ -128,7 +128,7 @@ public class CloudPublisherTest {
 
     @Test
     public void testOnWireReceiveWithBasicPosition()
-            throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+            throws InvalidSyntaxException, NoSuchFieldException {
         // test publishing a normal message with topic replacement and position
         givenCloudPublisher();
         givenDefaultProperties();
@@ -150,7 +150,7 @@ public class CloudPublisherTest {
     }
 
     @Test
-    public void testOnWireReceiveWithFullPosition() throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+    public void testOnWireReceiveWithFullPosition() throws InvalidSyntaxException, NoSuchFieldException {
         // test publishing a normal message with topic replacement and position
         givenCloudPublisher();
         givenDefaultProperties();
@@ -172,7 +172,46 @@ public class CloudPublisherTest {
     }
 
     @Test
-    public void testTopicReplacementOnWireReceive() throws InvalidSyntaxException, NoSuchFieldException, KuraException {
+    public void testOnWireReceiveWithBasicPositionWithNoPositionService() throws InvalidSyntaxException {
+        givenCloudPublisher();
+        givenDefaultProperties();
+        givenUpdatedProperties("publish.position", "basic");
+        givenActivatedComponentProperties();
+        givenDefaultRecordProp();
+
+        whenOnWireReceive();
+        whenKuraMessageReceived();
+
+        thenPayloadHasNullBody();
+        thenPayloadHasNullPosition();
+        thenTotalMetricReceived(2);
+        thenCheckDefaultMetricReceived();
+        thenTotalKuraMessagePropsReceived(2);
+        thenCheckDefaultKuraMessageProps();
+    }
+
+    @Test
+    public void testOnWireReceiveWithFullPositionWithNoPositionService() throws InvalidSyntaxException {
+        // test publishing a normal message with topic replacement and position
+        givenCloudPublisher();
+        givenDefaultProperties();
+        givenUpdatedProperties("publish.position", "full");
+        givenActivatedComponentProperties();
+        givenDefaultRecordProp();
+
+        whenOnWireReceive();
+        whenKuraMessageReceived();
+
+        thenPayloadHasNullBody();
+        thenPayloadHasNullPosition();
+        thenTotalMetricReceived(2);
+        thenCheckDefaultMetricReceived();
+        thenTotalKuraMessagePropsReceived(2);
+        thenCheckDefaultKuraMessageProps();
+    }
+
+    @Test
+    public void testTopicReplacementOnWireReceive() throws InvalidSyntaxException {
         // test publishing a normal message with topic replacement
         givenCloudPublisher();
         givenDefaultProperties();
@@ -273,7 +312,7 @@ public class CloudPublisherTest {
     }
 
     private void givenPositionServiceMock() {
-        this.positionServiceMock = mock(PositionService.class);
+        this.positionServiceMock = Optional.of(mock(PositionService.class));
     }
 
     private void givenFakeCloudPublisher() {
@@ -309,7 +348,7 @@ public class CloudPublisherTest {
     }
 
     private void whenSetPositionServiceMock() throws NoSuchFieldException {
-        when(this.positionServiceMock.getNmeaPosition())
+        when(this.positionServiceMock.get().getNmeaPosition())
                 .thenReturn(new NmeaPosition(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
         TestUtil.setFieldValue(this.cp, "positionService", this.positionServiceMock);
     }

--- a/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
+++ b/tests/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -192,7 +192,6 @@ public class CloudPublisherTest {
 
     @Test
     public void testOnWireReceiveWithFullPositionWithNoPositionService() throws InvalidSyntaxException {
-        // test publishing a normal message with topic replacement and position
         givenCloudPublisher();
         givenDefaultProperties();
         givenUpdatedProperties("publish.position", "full");


### PR DESCRIPTION
This pull request enhances the handling of the optional Position Service in the Cloud Publisher component, ensuring the component can operate correctly whether or not the Position Service is available. The changes also update documentation and tests to reflect this improved behavior.

**Cloud Publisher component improvements:**

* Refactored the `CloudPublisher` class to use `Optional<PositionService>`, updating the service binding methods to support dynamic availability and proper unbinding when the service is removed. This ensures the component works even if the Position Service is not present. [[1]](diffhunk://#diff-c25a7377d33db442df1673dd6ddca8b18ef5bcbab734a27867e17055e8f4fbadL66-R68) [[2]](diffhunk://#diff-c25a7377d33db442df1673dd6ddca8b18ef5bcbab734a27867e17055e8f4fbadL91-R99)
* Modified the logic for enriching messages with position information: now, if the Position Service is unavailable, a warning is logged and no position is added, instead of potentially causing a `NullPointerException`.
* Updated the OSGi XML descriptor to make the Position Service reference optional and dynamic, matching the new Java-side logic.

**Documentation and metadata updates:**

* Clarified in the component's metatype XML that position information will only be published if the Position Service is available.
* Updated copyright years in source and XML files. [[1]](diffhunk://#diff-c25a7377d33db442df1673dd6ddca8b18ef5bcbab734a27867e17055e8f4fbadL2-R2) [[2]](diffhunk://#diff-ab73f965d58f0d2bd4e9ec2d3b7b75b499d20ef3f10609bcc9ff0a0204ae3448L4-R4)
* Added a suggestion in the Debian control file to install the `kura-position` package if position support is desired.

**Testing improvements:**

* Updated tests to use `Optional<PositionService>`, added test cases for scenarios where the Position Service is not available, and removed unnecessary exception declarations. This ensures robust coverage for both presence and absence of the Position Service. [[1]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bR26) [[2]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL58-R59) [[3]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL67-R68) [[4]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL87-R88) [[5]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL108-R109) [[6]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL131-R131) [[7]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL153-R153) [[8]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL175-R214) [[9]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL276-R315) [[10]](diffhunk://#diff-714cd4db9fb0392cfb74de27c574a753bb1b6c1c5d724dbfff89663927e4ec2bL312-R351)